### PR TITLE
Add unit declarator to module, class and grammar declarations

### DIFF
--- a/lib/TestML.pm
+++ b/lib/TestML.pm
@@ -1,5 +1,5 @@
 use v6;
 
-module TestML;
+unit module TestML;
 
 our $*VERSION = '0.01';

--- a/lib/TestML/Parser/Grammar.pm
+++ b/lib/TestML/Parser/Grammar.pm
@@ -1,6 +1,6 @@
 use v6;
 
-grammar TestML::Parser::Grammar;
+unit grammar TestML::Parser::Grammar;
 
 our $block_marker = '===';
 our $point_marker = '---';

--- a/lib/TestML/Runner/TAP.pm
+++ b/lib/TestML/Runner/TAP.pm
@@ -3,7 +3,7 @@ use v6;
 use Test;
 use TestML::Runner;
 
-class TestML::Runner::TAP is TestML::Runner;
+unit class TestML::Runner::TAP is TestML::Runner;
 
 method title () {
     if $.doc.meta.data<Title> -> $title {

--- a/lib/TestML/Standard.pm
+++ b/lib/TestML/Standard.pm
@@ -1,5 +1,5 @@
 use v6;
-module TestML::Standard;
+unit module TestML::Standard;
 
 our sub Point($context, $name) {
     $context.point = $name;

--- a/t/Bridge.pm
+++ b/t/Bridge.pm
@@ -1,6 +1,6 @@
 use v6;
 
-module t::Bridge;
+unit module t::Bridge;
 
 our sub my_lower($context) {
     return $context.value.lc;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.