### PR TITLE
Fix hash initialization

### DIFF
--- a/lib/TestML/Parser.pm
+++ b/lib/TestML/Parser.pm
@@ -63,7 +63,7 @@ class TestML::Parser::Actions {
     method sq_string($/) { make ~$/ }
 
     method sq_escape($/) {
-        my %h = '\\' => "\\",
+        my %h = '\\' => "\\";
         make %h{~$/};
     }
 


### PR DESCRIPTION
Fix for variable initalizing itself error recently introduced in rakudo. Passes tests